### PR TITLE
Add `-i` option to `grep` for network checking

### DIFF
--- a/bin/mw
+++ b/bin/mw
@@ -60,7 +60,7 @@ _mwcheckcert() {
 _mwcheckinternet() {
   # Checks for internet connection
   if type systemctl >/dev/null; then
-    if ! systemctl --type service | grep net | grep active > /dev/null; then
+    if ! systemctl --type service | grep -i net | grep active > /dev/null; then
       echo "No internet connection."
       return 1
     fi

--- a/bin/mw
+++ b/bin/mw
@@ -95,7 +95,7 @@ _mwasktype() {
 }
 
 _mwaskinfo() {
-  if [ -z "$mwaddr" ]; then 
+  if [ -z "$mwaddr" ]; then
     printf "Type the \033[31memail address\033[0m\\n\t\033[36m"
     read -r mwaddr
     printf "\033[0m"


### PR DESCRIPTION
Add `-i` option to `grep` for network checking

Originally from https://github.com/rpuntaie/mailwizard/issues/3#issuecomment-530031414

Note - this is not a full fix for #3 - see https://github.com/rpuntaie/mailwizard/issues/3#issuecomment-530054715 for the full fix. 